### PR TITLE
Add Spanish 404 redirect, access-code overlay on index, and README preview note

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Redirigiendo…</title>
+  <meta http-equiv="refresh" content="0; url=/index.html" />
+  <script>
+    window.location.replace('/index.html');
+  </script>
+  <style>
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      font-family: Arial, sans-serif;
+      background: #f0f2f5;
+      color: #1a1a1a;
+    }
+
+    .contenedor {
+      background: #fff;
+      border-radius: 10px;
+      padding: 20px;
+      box-shadow: 0 6px 20px rgba(0, 0, 0, 0.15);
+      text-align: center;
+      max-width: 320px;
+    }
+  </style>
+</head>
+<body>
+  <div class="contenedor">
+    <h1>Página no encontrada</h1>
+    <p>Te estamos redirigiendo al inicio…</p>
+    <p><a href="/index.html">Ir ahora</a></p>
+  </div>
+</body>
+</html>

--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # Para-Mishell
+
+## Vista previa local
+Si te aparece **Not Found** en la vista previa, abre la ruta raíz del proyecto (`/`) o directamente `index.html`.
+
+También se agregó un `404.html` con redirección automática al inicio para entornos de hosting estático que lo soportan.

--- a/index.html
+++ b/index.html
@@ -1,12 +1,123 @@
 <!DOCTYPE html>
-<html>
+<html lang="es">
 <head>
-<title>Mi página</title>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Mi página</title>
+  <style>
+    :root {
+      font-family: Arial, sans-serif;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background: #f0f2f5;
+    }
+
+    .pantalla-acceso {
+      position: fixed;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: rgba(0, 0, 0, 0.45);
+      z-index: 10;
+    }
+
+    .recuadro-codigo {
+      width: min(280px, 85vw);
+      padding: 18px;
+      border-radius: 10px;
+      background: #ffffff;
+      box-shadow: 0 8px 22px rgba(0, 0, 0, 0.22);
+      text-align: center;
+    }
+
+    .recuadro-codigo h2 {
+      margin: 0 0 10px;
+      font-size: 1rem;
+    }
+
+    .recuadro-codigo input {
+      width: 100%;
+      box-sizing: border-box;
+      padding: 10px;
+      margin-bottom: 10px;
+      border: 1px solid #c8c8c8;
+      border-radius: 6px;
+      font-size: 0.95rem;
+    }
+
+    .recuadro-codigo button {
+      width: 100%;
+      padding: 10px;
+      border: none;
+      border-radius: 6px;
+      background: #2f6fed;
+      color: white;
+      font-weight: 600;
+      cursor: pointer;
+    }
+
+    .mensaje-error {
+      margin: 10px 0 0;
+      color: #d12d2d;
+      font-size: 0.85rem;
+      min-height: 1em;
+    }
+
+    .contenido {
+      display: none;
+      padding: 40px 20px;
+      text-align: center;
+    }
+
+    .contenido.visible {
+      display: block;
+    }
+  </style>
 </head>
-
 <body>
-<h1>Bienvenido a mi página</h1>
-<p>Esta es mi primera web.</p>
-</body>
+  <div class="pantalla-acceso" id="pantallaAcceso">
+    <div class="recuadro-codigo">
+      <h2>Ingresa el código de acceso</h2>
+      <input id="codigoInput" type="password" placeholder="Código" />
+      <button id="btnAcceder" type="button">Acceder</button>
+      <p id="mensajeError" class="mensaje-error"></p>
+    </div>
+  </div>
 
+  <main id="contenido" class="contenido" aria-hidden="true">
+    <h1>Bienvenido a mi página</h1>
+    <p>Esta es mi primera web.</p>
+  </main>
+
+  <script>
+    const ACCESS_CODE = "1234";
+    const pantallaAcceso = document.getElementById("pantallaAcceso");
+    const codigoInput = document.getElementById("codigoInput");
+    const btnAcceder = document.getElementById("btnAcceder");
+    const mensajeError = document.getElementById("mensajeError");
+    const contenido = document.getElementById("contenido");
+
+    function validarCodigo() {
+      if (codigoInput.value === ACCESS_CODE) {
+        pantallaAcceso.style.display = "none";
+        contenido.classList.add("visible");
+        contenido.setAttribute("aria-hidden", "false");
+        mensajeError.textContent = "";
+      } else {
+        mensajeError.textContent = "Código incorrecto. Intenta de nuevo.";
+      }
+    }
+
+    btnAcceder.addEventListener("click", validarCodigo);
+    codigoInput.addEventListener("keydown", (event) => {
+      if (event.key === "Enter") {
+        validarCodigo();
+      }
+    });
+  </script>
+</body>
 </html>


### PR DESCRIPTION
### Motivation
- Provide a friendly fallback for static hosts that show a 404 page by redirecting users to the site root. 
- Improve the local preview experience by documenting how to access the site root in the `README.md`.
- Add a simple access-code overlay to `index.html` to demonstrate gated content and improve initial styling and accessibility.

### Description
- Added `404.html` which performs an immediate redirect to `/index.html` via a meta refresh and `window.location.replace`, and includes a minimal Spanish UI for users that land there. 
- Reworked `index.html` to include `lang="es"`, meta charset/viewport tags, updated styles, and a modal-like access screen with an input, a `button`, and client-side validation using the `ACCESS_CODE` constant. 
- Implemented visibility toggling and basic accessibility attributes (`aria-hidden`) for the gated content, plus keyboard support for Enter key submission. 
- Updated `README.md` to include a local preview note and mention the new `404.html` redirect behavior.

### Testing
- No automated tests were added or run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0a9345504832eab49687ea131cd25)