### PR TITLE
Restringir acceso a códigos 2303/2868 y mostrar confirmación de ingreso

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,11 +60,18 @@
       cursor: pointer;
     }
 
-    .mensaje-error {
+    .mensaje-estado {
       margin: 10px 0 0;
-      color: #d12d2d;
       font-size: 0.85rem;
       min-height: 1em;
+    }
+
+    .mensaje-estado.error {
+      color: #d12d2d;
+    }
+
+    .mensaje-estado.exito {
+      color: #1c9b3b;
     }
 
     .contenido {
@@ -82,33 +89,48 @@
   <div class="pantalla-acceso" id="pantallaAcceso">
     <div class="recuadro-codigo">
       <h2>Ingresa el código de acceso</h2>
-      <input id="codigoInput" type="password" placeholder="Código" />
+      <input id="codigoInput" type="password" placeholder="Código de 4 dígitos" maxlength="4" inputmode="numeric" />
       <button id="btnAcceder" type="button">Acceder</button>
-      <p id="mensajeError" class="mensaje-error"></p>
+      <p id="mensajeEstado" class="mensaje-estado"></p>
     </div>
   </div>
 
   <main id="contenido" class="contenido" aria-hidden="true">
-    <h1>Bienvenido a mi página</h1>
-    <p>Esta es mi primera web.</p>
+    <h1>Bienvenido</h1>
+    <p>Has ingresado correctamente a la página principal.</p>
   </main>
 
   <script>
-    const ACCESS_CODE = "1234";
+    const CODIGOS_VALIDOS = {
+      administrador: "2303",
+      usuario: "2868",
+    };
     const pantallaAcceso = document.getElementById("pantallaAcceso");
     const codigoInput = document.getElementById("codigoInput");
     const btnAcceder = document.getElementById("btnAcceder");
-    const mensajeError = document.getElementById("mensajeError");
+    const mensajeEstado = document.getElementById("mensajeEstado");
     const contenido = document.getElementById("contenido");
 
+    function mostrarMensaje(texto, tipo) {
+      mensajeEstado.textContent = texto;
+      mensajeEstado.className = `mensaje-estado ${tipo}`;
+    }
+
+    function abrirPaginaPrincipal() {
+      pantallaAcceso.style.display = "none";
+      contenido.classList.add("visible");
+      contenido.setAttribute("aria-hidden", "false");
+    }
+
     function validarCodigo() {
-      if (codigoInput.value === ACCESS_CODE) {
-        pantallaAcceso.style.display = "none";
-        contenido.classList.add("visible");
-        contenido.setAttribute("aria-hidden", "false");
-        mensajeError.textContent = "";
+      const codigoIngresado = codigoInput.value.trim();
+      const esCodigoValido = Object.values(CODIGOS_VALIDOS).includes(codigoIngresado);
+
+      if (esCodigoValido) {
+        mostrarMensaje("Ingreso exitoso", "exito");
+        setTimeout(abrirPaginaPrincipal, 900);
       } else {
-        mensajeError.textContent = "Código incorrecto. Intenta de nuevo.";
+        mostrarMensaje("Código incorrecto. Intenta de nuevo.", "error");
       }
     }
 


### PR DESCRIPTION
### Motivation
- Limitar el acceso a solo dos códigos numéricos de 4 dígitos (Administrador y Usuario) y proporcionar retroalimentación visual clara al usuario. 
- Tras un ingreso válido, navegar a la página principal y mostrar un mensaje de bienvenida.

### Description
- Reemplacé la constante de acceso por `CODIGOS_VALIDOS` con `administrador: "2303"` y `usuario: "2868"` y validación contra esos valores. 
- Ajusté el input para `maxlength="4"` y `inputmode="numeric"` y actualicé el placeholder a `"Código de 4 dígitos"`. 
- Reemplacé el elemento de mensaje por `mensajeEstado` con clases `error` y `exito`, estilos correspondientes (rojo/verde) y la función `mostrarMensaje` para manejar el estado. 
- Al validar correctamente se muestra `"Ingreso exitoso"` en verde y, tras un pequeño retraso (`setTimeout`), se oculta la pantalla de acceso y se muestra el `main` con el encabezado `Bienvenido`.

### Testing
- Inspeccioné el archivo modificado con `nl -ba index.html | sed -n '1,240p'` para verificar los cambios de código y estructura, y la verificación fue satisfactoria. 
- Inicié un servidor estático con `python3 -m http.server 4173` para servir `index.html` y confirmar que el archivo era accesible desde el entorno. 
- Intenté ejecutar un script automático con Playwright para completar el formulario y tomar una captura, pero el intento falló porque Chromium en este entorno terminó con un `SIGSEGV`, por lo que la prueba automática de UI no pudo completarse.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0adc38a88832eb9f0a677790b5754)